### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui_magicclothing"
+description = "implementation of MagicClothing with garment and prompt in ComfyUI"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["insightface==0.7.3", "onnxruntime-gpu==1.17.1", "--extra-index-url https://download.pytorch.org/whl/cu118", "torch==2.1.1+cu118", "torchvision==0.16.1+cu118", "numpy==1.25.1", "diffusers==0.26.2", "opencv-python==4.9.0.80", "transformers==4.31.0", "safetensors==0.3.1", "controlnet-aux==0.0.6", "accelerate==0.21.0"]
+
+[project.urls]
+Repository = "https://github.com/frankchieng/ComfyUI_MagicClothing"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI_MagicClothing"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!